### PR TITLE
Same field in data area more than once with different type of aggregation

### DIFF
--- a/src/js/orb.config.js
+++ b/src/js/orb.config.js
@@ -261,7 +261,7 @@ module.exports.config = function(config) {
     //    fieldconfig = ensureFieldConfig(fieldconfig);
     //    return createfield(self, axe.Type.DATA, fieldconfig, getfield(self.allFields, fieldconfig.name));
     //});
-    
+    // Identify the fields in data are by their caption, which is expected to be unique, rather than just name
     this.dataFields = (config.data || []).map(function(fieldconfig1) {
         let fieldconfig = ensureFieldConfig(fieldconfig1);
         return createfield(self, axe.Type.DATA, fieldconfig, getfieldForDataByCaption(self.allFields, fieldconfig1));

--- a/src/js/orb.config.js
+++ b/src/js/orb.config.js
@@ -255,11 +255,21 @@ module.exports.config = function(config) {
         return createfield(self, axe.Type.COLUMNS, fieldconfig, getfield(self.allFields, fieldconfig.name));
     });
 
-    this.dataFields = (config.data || []).map(function(fieldconfig) {
-        fieldconfig = ensureFieldConfig(fieldconfig);
-        return createfield(self, axe.Type.DATA, fieldconfig, getfield(self.allFields, fieldconfig.name));
+    // Fix 001 Start for same field is needed multiple times in data area.
+
+    //this.dataFields = (config.data || []).map(function(fieldconfig) {
+    //    fieldconfig = ensureFieldConfig(fieldconfig);
+    //    return createfield(self, axe.Type.DATA, fieldconfig, getfield(self.allFields, fieldconfig.name));
+    //});
+    
+    this.dataFields = (config.data || []).map(function(fieldconfig1) {
+        let fieldconfig = ensureFieldConfig(fieldconfig1);
+        return createfield(self, axe.Type.DATA, fieldconfig, getfieldForDataByCaption(self.allFields, fieldconfig1));
     });
 
+    // Fix 001 End
+    
+    
     this.dataFieldsCount = this.dataFields ? (this.dataFields.length || 1) : 1;
 
     var runtimeVisibility = {

--- a/src/js/orb.config.js
+++ b/src/js/orb.config.js
@@ -286,7 +286,46 @@ module.exports.config = function(config) {
         }
         return null;
     }
+    
+    // Fix 001 Start for same field is needed multiple times in data area.
+    
+    // Identify the fields in data are by their caption, which is expected to be unique, rather than just name
+    // Added below code for 3 function to get field data based on caption, which is unique, instead of field name
+    function getfieldByCaption(axefields, fieldCaption) {
+        var fieldindex = getfieldindexByCaption(axefields, fieldCaption);
+        if (fieldindex > -1) {
+            return axefields[fieldindex];
+        }
+        return null;
+    }
+    function getfieldForDataByCaption(axefields, fieldCaption) {
+        var fieldindex = getfieldindexByCaption(axefields, fieldCaption);//self.dataSourceFieldCaptions.indexOf(fieldCaption);//getfieldindex(axefields, fieldname);
+        if (fieldindex > -1) {
+            return axefields[fieldindex];
+        }
+        return null;
+    }
+    function getfieldindexByCaption(axefields, fieldCaption) {
+        for (var fi = 0; fi < axefields.length; fi++) {
+            if (axefields[fi].caption === fieldCaption) {
+                return fi;
+            }
+        }
+        return -1;
+    }
+    this.getDataFieldByCaption = function(fieldCaption) {
+        return getfieldByCaption(self.dataFields, fieldCaption);
+    };
 
+    function getfieldForData(axefields, fieldname) {
+        var fieldindex = getfieldindex(axefields, fieldname);
+        if (fieldindex > -1) {
+            return axefields[fieldindex];
+        }
+        return null;
+    }
+    // FIX 001 END
+    
     function getfieldindex(axefields, fieldname) {
         for (var fi = 0; fi < axefields.length; fi++) {
             if (axefields[fi].name === fieldname) {

--- a/src/js/orb.pgrid.js
+++ b/src/js/orb.pgrid.js
@@ -143,7 +143,16 @@ module.exports = function(config) {
         if (rowdim && coldim) {
 
             var datafieldName = field || (self.config.dataFields[0] || defaultfield).name;
-            var datafield = self.config.getDataField(datafieldName);
+            
+            // Fix 001 Start for same field is needed multiple times in data area.
+            // Identify the fields in data are by their caption, which is expected to be unique, rather than just name
+            
+            // Replaced below line by mext 2 lines
+            //var datafield = self.config.getDataField(datafieldName);
+            var fieldCaption = field || (self.config.dataFields[0] || defaultfield).caption;
+            var datafield = self.config.getDataFieldByCaption(fieldCaption);
+
+            // Fix 001 END
             
             if(!datafield || (aggregateFunc && datafield.aggregateFunc != aggregateFunc)) {
                 value = self.calcAggregation(
@@ -235,7 +244,15 @@ module.exports = function(config) {
                 if(emptyIntersection) {
                     res[datafield.field.name] = null;
                 } else {
-                    res[datafield.field.name] = datafield.aggregateFunc(datafield.field.name, intersection || 'all', self.filteredDataSource, origRowIndexes || rowIndexes, colIndexes);
+                    
+                    // Fix 001 Start for same field is needed multiple times in data area.
+                    // Identify the fields in data are by their caption, which is expected to be unique, rather than just name
+                    
+                    // Replaced below line by next line
+                    //res[datafield.field.name] = datafield.aggregateFunc(datafield.field.name, intersection || 'all', self.filteredDataSource, origRowIndexes || rowIndexes, colIndexes);
+                    res[datafield.field.caption] = datafield.aggregateFunc(datafield.field.name, intersection || 'all', self.filteredDataSource, origRowIndexes || rowIndexes, colIndexes);
+                    
+                    // Fix 001 END
                 }
             }
         }

--- a/src/js/orb.ui.header.js
+++ b/src/js/orb.ui.header.js
@@ -295,7 +295,15 @@ module.exports.dataCell = function(pgrid, isvisible, rowinfo, colinfo) {
         axetype: null,
         type: HeaderType.DATA_VALUE,
         template: 'cell-template-datavalue',
-        value: pgrid.getData(this.datafield ? this.datafield.name : null, this.rowDimension, this.columnDimension),
+        
+        // Fix 001 Start for same field is needed multiple times in data area.
+        // Identify the fields in data are by their caption, which is expected to be unique, rather than just name
+        
+        // Replaced below line by next line
+        //value: pgrid.getData(this.datafield ? this.datafield.name : null, this.rowDimension, this.columnDimension),
+        value: pgrid.getData(this.datafield ? this.datafield.caption : null, this.rowDimension, this.columnDimension),
+        // Fix 001 END
+        
         cssclass: 'cell ' + HeaderType.getCellClass(this.rowType, this.colType),
         isvisible: isvisible
     });


### PR DESCRIPTION
It is required to have same field in data area more than once with different type of aggregation
For ex. I want to see the sum of sales amount side by side with average sale amount or count of sale deals
[{name:"Amount", caption: 'Amount Sum', dataSettings: { aggregateFunc: 'sum'}},
 {name:"Amount", caption: 'Amount Count', dataSettings: { aggregateFunc: 'count'}},
 {name:"Amount", caption: 'Amount Avg', dataSettings: { aggregateFunc: 'avg'}}]

data    : [ 'Amount Sum', 'Amount Count', 'Amount Avg'  ],

The proposal is to identify and process fields in data area Not By name property by Caption property.